### PR TITLE
Disc refactoring

### DIFF
--- a/templates/test/processors/disc_create.js
+++ b/templates/test/processors/disc_create.js
@@ -56,14 +56,28 @@ module.exports = {
                 postData.editors = funcs.checkAndAddEditors(userInfo, postData);
                 postData.groups = funcs.convertToArray(postData.groups);
 
-                dbMethods.addDisciplineToDB(userInfo, postData, db, err => {
+                dbMethods.findDisciplineByAllias(postData.allias, db, (err, discFound) => {
 
-                  if(err) return bw.redirectTo500Page(response, err, callback);
+                  if (err) return bw.redirectTo500Page(response, err, callback);
+                  if (discFound) {
+                    return callback({
+                      title: 'Новая дисциплина',
+                      discipline: postData,
+                      groupsInfo: groupsInfo,
+                      teachersList: teachersList,
+                      userInfo: userInfo,
+                      errorMessage: 'Дисциплина с таким URL уже существует!'
+                    }, 'disc_form', 0, 0 );
+                  }
 
-                  console.log(`Discipline ${postData.allias} created!`);
-                  return bw.redirectToDiscPage(response, callback);
-                });
+                  dbMethods.addDisciplineToDB(userInfo, postData, db, err => {
 
+                    if(err) return bw.redirectTo500Page(response, err, callback);
+
+                    console.log(`Discipline ${postData.allias} created!`);
+                    return bw.redirectToDiscPage(response, callback);
+                  });//addDisciplineToDB
+                }); //findDisciplineByAllias
               } catch(err) {
                 console.log(`Processor error disc_create: ${err}`);
                 return bw.redirectTo500Page(response, err, callback);

--- a/templates/test/processors/disc_delete.js
+++ b/templates/test/processors/disc_delete.js
@@ -1,95 +1,69 @@
-const qs = require('querystring'),
-      router = require('../../../router'),
-      path = require('path'),
-      fs = require('fs');
+const check = require('./common/permission_check.js'),
+      bw = require('./common/bleed_wrapper.js'),
+      dbMethods = require('./disciplines/dbMethods.js'),
+      funcs = require('./disciplines/funcs.js');
+
 
 module.exports = {
   path: new RegExp('^\/disciplines\/delete\/[^\/]+\/$'),
-  processor: function(request, response, callback, sessionContext, sessionToken, db){
-    if(sessionToken == null || sessionContext == undefined || sessionContext == null){
-      callback();
-      return router.bleed(301, '/login/', response);
-    }
-    requestedUrl = decodeURI(request.url);
-    delimeteredUrl = requestedUrl.split('/');
-    disciplineAllias = delimeteredUrl[delimeteredUrl.length-2];
-    db.collection('users').findOne({_id: sessionContext.id},{username: 1, securityRole: 1}, function(err, result){
-      if(err){
-        callback();
-        return  router.bleed(500, null, response);
-      }
-      if(result == null){
-        callback();
-        return router.bleed(301, '/login/', response);
-      }
+  processor(request, response, callback, sessionContext, sessionToken, db) {
+
+    const userAuthed = check.isUserAuthed(sessionContext, sessionToken);
+    if (!userAuthed) return bw.redirectToLoginPage(response, callback);
+
+    dbMethods.getRoleForAuthedUser(sessionContext.id, db, (err, result) => {
+
+      if (err) return bw.redirectTo500Page(response, err, callback);
+
       const userInfo = result;
-      if(userInfo.securityRole.length == 0 || ((!userInfo.securityRole.includes('superadmin') && !userInfo.securityRole.includes('teacher')))){
-        callback();
-        return router.bleed(403, null, response);
+      const userAdminOrTeacher = check.isUserAdminOrTeacher(userInfo);
+      if (!userAdminOrTeacher) {
+        const err = new Error('User role not admin or teacher');
+        return bw.redirectWithErrorCode(response, 403, err, callback);
       }
-      db.collection('disciplines').findOne({allias: disciplineAllias}, {name: 1, editors: 1, files: 1}, function(err, result){
-        if(err){
-          callback();
-          return router.bleed(500, null, response);
-        }
-        if(result == null){
-          callback();
-          return router.bleed(301, '/disciplines/', response);
-        }
+
+      const disciplineAllias = funcs.getDiscAlliasFromUrl(request.url);
+
+      dbMethods.findDisciplineByAllias(disciplineAllias, db, (err, result) => {
+
+        if (err) return bw.redirectTo500Page(response, err, callback);
+        if (!result) return bw.redirectTo404Page(response, request.url, callback);
+
         const discipline = result;
-        if(!(userInfo.securityRole.includes('superadmin')) && !(discipline.editors.includes(userInfo._id.toString()))){
-          callback();
-          return router.bleed(301, '/disciplines/', response);
+
+        const teacherEditor = check.isTeacherDiscEditor(userInfo, discipline);
+        if (!teacherEditor) {
+          const err = new Error('Teacher is not discipline editor');
+          return bw.redirectWithErrorCode(response, 403, err, callback);
         }
-        if(request.method == 'POST') {
-          deleteAtachedFiles(discipline, db, (err) => {
-            if(err) {
-              console.log(`Error with delete files in disc_delete: ${err}`);
-            } else{
-              console.log(`Delete files successful for ${disciplineAllias}`);
-            }
-          });
-          db.collection('disciplines').deleteOne({allias: disciplineAllias}, function(err, result){
-                if(err){
-                  callback();
-                  return router.bleed(500, null, response, err);
-                }
-                callback();
-                console.log(`Discipline '${disciplineAllias}' deleted!`);
-                return router.bleed(301, '/disciplines/', response);
-              });
-        } else {
+
+        if (request.method !== 'POST') {
           return callback({
             title: 'Удаление дисциплины',
             discipline: discipline
           }, 'disc_delete', 0, 0);
         }
-      });
-    });
-  }
-}
-function deleteAtachedFiles(discipline, db, callback){
-  let fileNames = discipline.files;
-  if(fileNames.length == 0) return callback(null);
-  const STORAGE_DATA_LOCATION = process.env['STORAGE_DATA_LOCATION'] ? `${process.env['STORAGE_DATA_LOCATION']}/private` : '';
-  const PATH_TO_FILES = STORAGE_DATA_LOCATION || path.join(__dirname, '../../../', '/data/private');
-  let dirName = '',
-      dirFiles = [];
-  try{
-    for (let file of fileNames){
-      dirName = file.substr(0, 2);
-      fs.unlinkSync(`${PATH_TO_FILES}/${dirName}/${file}`);
-      let deletionResult = db.collection('files').remove({_id: file});
-      dirFiles = fs.readdirSync(`${PATH_TO_FILES}/${dirName}/`);
-      if(dirFiles.length == 0){
-        fs.rmdir(`${PATH_TO_FILES}/${dirName}/`, (err) =>{
-          if(err) console.log(`Error with delete folder ${PATH_TO_FILES}/${dirName}/: ${err}`)
-          console.log(`Folder ${PATH_TO_FILES}/${dirName}/ was deleted`);
-        });
-      }
-    }
-    callback(null);
-  }catch(err){
-    callback(err);
+
+        //get attached files to discipline
+        const fileIDs = discipline.files;
+        //delete attached files if exists
+        if (fileIDs.length > 0) {
+          funcs.deleteDisciplineFiles(fileIDs, db, errorCount => {
+            if (errorCount > 0) {
+              console.log(`${errorCount} delete errors!`);
+            } else {
+              console.log(`Delete files successful for ${disciplineAllias}`);
+            }
+          });
+        }
+
+        dbMethods.deleteDiscFromDB(disciplineAllias, db, (err, result) => {
+          if (err) return bw.redirectTo500Page(response, err, callback);
+
+          console.log(`Discipline '${disciplineAllias}' deleted!`);
+          return bw.redirectToDiscPage(response, callback);
+        });//deleteDiscFromDB
+      }); //findDisciplineByAllias
+    }); //getRoleForAuthedUser
   }
 }

--- a/templates/test/processors/disc_detail.js
+++ b/templates/test/processors/disc_detail.js
@@ -1,76 +1,61 @@
-const qs = require('querystring'),
-      router = require('../../../router'),
-      security = require('../../../security'),
-      beautyDate = require('../../../beautyDate');
+const beautyDate = require('../../../beautyDate'),
+  check = require('./common/permission_check.js'),
+  bw = require('./common/bleed_wrapper.js'),
+  dbMethods = require('./disciplines/dbMethods.js'),
+  funcs = require('./disciplines/funcs.js');
 
 module.exports = {
   path: new RegExp('^\/disciplines\/[^\/]+\/$'),
-  processor: function(request, response, callback, sessionContext, sessionToken, db){
-    const userAuthed = isUserAuthed(sessionContext, sessionToken);
-    if(!userAuthed) return redirectToLoginPage(response, callback);
+  processor(request, response, callback, sessionContext, sessionToken, db) {
 
-    let requestedUrl = decodeURI(request.url);
-    let delimeteredUrl = requestedUrl.split('/');
-    let disciplineAllias = delimeteredUrl[delimeteredUrl.length-2];
+    const userAuthed = check.isUserAuthed(sessionContext, sessionToken);
+    if (!userAuthed) return bw.redirectToLoginPage(response, callback);
 
-    db.collection('disciplines').findOne({allias : disciplineAllias}, function(err, result) {
-      if(err) return redirectTo500Page(response, callback, err);
+    dbMethods.getRoleForAuthedUser(sessionContext.id, db, (err, result) => {
 
-      if(result == null) {
-        callback();
-        console.log(`Not found discipline '${disciplineAllias}' redirecting on disciplines list...`);
-        return router.bleed(301, '/disciplines/', response);
-      }
+      if (err) return bw.redirectTo500Page(response, err, callback);
+      const userInfo = result;
 
-      const disc_detail = result;
-      let disc_files = [];
-      db.collection('users').findOne({_id : sessionContext.id}, {securityRole : 1, username : 1}, function(err, result){
-        if(err) return redirectTo500Page(response, callback, err);
-        let userInfo = result;
-        if(disc_detail.files.length == 0) {
+      const discAllias = funcs.getDiscAlliasFromUrl(request.url);
+
+      dbMethods.findDisciplineByAllias(discAllias, db, (err, result) => {
+
+        if (err) return bw.redirectTo500Page(response, callback, err);
+        if (result == null)
+            return bw.redirectTo404Page(response, request.url, callback);
+
+        const discipline = result;
+        let discFiles = funcs.convertToArray(discipline.files);
+
+        if (discFiles.length == 0) {
           return callback({
             title: 'О дисциплине',
             userInfo: userInfo,
-            discipline: disc_detail,
-            files: disc_files
+            discipline: discipline,
+            files: discFiles
           }, 'disc_detail', 0, 0);
         }
-        db.collection('files').find(
-          { _id: {$in: disc_detail.files } })
-          .sort( {dateEdit: -1} )
-          .toArray(function(err, result) {
-          if(err) return redirectTo500Page(response, callback, err);
-          disc_files = result;
-          for ( let file of disc_files ) {
+
+        dbMethods.findDisciplineFiles(discFiles, db, (err, result) => {
+
+          if (err) return bw.redirectTo500Page(response, err, callback);
+          discFiles = result;
+
+          discFiles.forEach(file => {
             file.formatedDate = beautyDate(file.dateEdit);
             file.fullName = `${file.name}.${file.ext}`;
             const dirName = file._id.substr(0,2);
             file.fullPath = `/${dirName}/${file._id}`;
-          }
+          });
+
           return callback({
             title: 'О дисциплине',
             userInfo: userInfo,
-            discipline: disc_detail,
-            files: disc_files
+            discipline: discipline,
+            files: discFiles
           }, 'disc_detail', 0, 0);
-        });
-      });
-    });
+        }); //findDisciplineFiles
+      }); //findDisciplineByAllias
+    }); //getRoleForAuthedUser
   }
-}
-
-function isUserAuthed(sessionContext, sessionToken) {
-  return (typeof sessionToken === 'string' &&
-    sessionContext instanceof Object &&
-    sessionContext['id'] !== undefined);
-}
-
-function redirectToLoginPage(response, callback) {
-  callback();
-  return router.bleed(301, '/login/', response);
-}
-
-function redirectTo500Page(response, callback, err) {
-  callback();
-  return router.bleed(500, null, response, err);
-}
+};

--- a/templates/test/processors/disc_edit.js
+++ b/templates/test/processors/disc_edit.js
@@ -1,139 +1,103 @@
 const qs = require('querystring'),
-      router = require('../../../router'),
-      security = require('../../../security');
+  downloadClientPostData = require('../../../router').downloadClientPostData,
+  check = require('./common/permission_check.js'),
+  bw = require('./common/bleed_wrapper.js'),
+  dbMethods = require('./disciplines/dbMethods.js'),
+  funcs = require('./disciplines/funcs.js');
 
 module.exports = {
   path: new RegExp('^\/disciplines\/edit\/[^\/]+\/$'),
-  processor: function(request, response, callback, sessionContext, sessionToken, db) {
-    if(sessionToken == null || sessionContext == undefined || sessionContext == null) {
-      callback();
-      return router.bleed(301, '/login/', response);
-    }
-    requestedUrl = decodeURI(request.url);
-    delimeteredUrl = requestedUrl.split('/');
-    disciplineAllias = delimeteredUrl[delimeteredUrl.length-2];
-    db.collection('users').findOne({_id : sessionContext.id}, {username : 1, securityRole: 1}, function(err, result) {
-      if(err) {
-        callback();
-        router.bleed(500, null, response, err);
-      }
+  processor(request, response, callback, sessionContext, sessionToken, db) {
+
+    const userAuthed = check.isUserAuthed(sessionContext, sessionToken);
+    if (!userAuthed) return bw.redirectToLoginPage(response, callback);
+
+    dbMethods.getRoleForAuthedUser(sessionContext.id, db, (err, result) => {
+
+      if (err) return bw.redirectTo500Page(response, err, callback);
       const userInfo = result;
-      if(userInfo.securityRole.length == 0 || (!userInfo.securityRole.includes('superadmin') && !userInfo.securityRole.includes('teacher'))){
-        callback();
-        return router.bleed(403, null, response);
+
+      const userAdminOrTeacher = check.isUserAdminOrTeacher(userInfo);
+      if (!userAdminOrTeacher) {
+        const err = new Error('User role not admin or teacher');
+        return bw.redirectWithErrorCode(response, 403, err, callback);
       }
-      db.collection('disciplines').findOne({allias: disciplineAllias}, function(err, result) {
-        if(err) {
-          callback();
-          router.bleed(500, null, response, err);
+
+      let discAllias = funcs.getDiscAlliasFromUrl(request.url);
+
+      dbMethods.findDisciplineByAllias(discAllias, db, (err, result) => {
+
+        if (err) return bw.redirectTo500Page(response, err, callback);
+        if (!result) return bw.redirectTo404Page(response, request.url, callback);
+
+        const discipline = result;
+
+        const teacherEditor = check.isTeacherDiscEditor(userInfo, discipline);
+        if (!teacherEditor) {
+          const err = new Error('Teacher is not discipline editor');
+          return bw.redirectWithErrorCode(response, 403, err, callback);
         }
-        if(result == null){
-          console.log(`Not found discipline '${disciplineAllias}' redirecting on disciplines list...`);
-          callback();
-          router.bleed(301, '/disciplines/', response);
-        }
-        const disc_detail = result;
-        db.collection('groups').find().toArray(function(err, result) {
-          if(err) {
-            callback();
-            router.bleed(500, null, response, err);
-          }
+
+        dbMethods.getAllGroups(db, (err, result) => {
+
+          if (err) return bw.redirectTo500Page(response, err, callback);
           const groupsInfo = result;
-          db.collection('users').find({securityRole: 'teacher'}).toArray(function(err, result) {
-            if(err) {
-              callback();
-              router.bleed(500, null, response, err);
-            }
+
+          dbMethods.getAllTeachers(db, (err, result) => {
+
+            if (err) return bw.redirectTo500Page(response, err, callback);
             const teachersList = result;
-            if(request.method == 'POST') {
-              return router.downloadClientPostData(request, function(err, data){
-                if(err) {
-                  callback();
-                  return router.bleed(500, null, response, err);
-                }
-                try {
-                  const postData = qs.parse(data);
-                  if(/[А-яЁё]/gi.test(postData.allias)){
-                    return callback({
-                      title: 'Изменение дисциплины',
-                      discipline: postData,
-                      groupsInfo: groupsInfo,
-                      userInfo: userInfo,
-                      teachersList: teachersList,
-                      errorMessage: 'Новое имя ссылки(URL) должно быть на английском!'
-                    }, 'disc_form', 0, 0 );
-                  }
-                  if(/\/|http|@|:|ftp/gi.test(postData.allias)){
-                    return callback({
-                      title: 'Изменение дисциплины',
-                      discipline: postData,
-                      groupsInfo: groupsInfo,
-                      userInfo: userInfo,
-                      teachersList: teachersList,
-                      errorMessage: 'Неправильное имя ссылки(URL) для дисциплины!'
-                    }, 'disc_form', 0, 0 );
-                  }
-                  let editors = [];
-                  if(userInfo.securityRole.includes('teacher')) {
-                    editors = convertToArray(disc_detail.editors);
-                  } else {
-                      editors = convertToArray(postData.editors);
-                  }
-                  db.collection('disciplines').findOneAndUpdate({allias: disciplineAllias}, { $set: {
-                    name: postData.name,
-                    mnemo: postData.mnemo,
-                    allias: postData.allias,
-                    description: postData.description,
-                    groups: convertToArray(postData.groups),
-                    dateUpdate: new Date(),
-                    lastEditor: userInfo._id,
-                    editors: editors
-                    }
-                  }, function(err, result){
-                    if(err) {
-                      callback();
-                      return router.bleed(500, null, response, err);
-                    }
-                    if(result.value == null) {
-                      return callback({
-                        title: 'Изменение дисциплины',
-                        discipline: postData,
-                        groupsInfo: groupsInfo,
-                        userInfo: userInfo,
-                        teachersList: teachersList,
-                        errorMessage: 'Что-то не так с обновлением, попробуйте снова.'
-                      }, 'disc_form', 0, 0 );
-                    }
-                    console.log(`Discipline ${postData.allias} updated!`);
-                    callback();
-                    return router.bleed(301, `/disciplines/${postData.allias}/`, response);
-                  });
-                } catch(err){
-                  console.log(`Proccesor error disc_update: ${err}`);
-                  callback();
-                  return router.bleed(500, null, response, err);
-                }
-              }, 10000000);
-            } else{
+
+            if (request.method !== 'POST') {
               return callback({
                 title: 'Изменение дисциплины',
-                discipline: disc_detail,
+                discipline: discipline,
                 groupsInfo: groupsInfo,
                 userInfo: userInfo,
                 teachersList: teachersList,
                 errorMessage: ''
               }, 'disc_form', 0, 0);
             }
-          });
-        });
-      });
-    });
+              //required from router.js for download Client Post Data
+            return downloadClientPostData(request, (err, data) => {
+              if (err) return bw.redirectTo400Page(response, callback);
+
+              try {
+                const postData = qs.parse(data);
+
+                const errorMessage = funcs.checkDiscAllias(postData.allias);
+                if (errorMessage) {
+                  return callback({
+                    title: 'Новая дисциплина',
+                    discipline: postData,
+                    groupsInfo: groupsInfo,
+                    teachersList: teachersList,
+                    userInfo: userInfo,
+                    errorMessage: errorMessage
+                  }, 'disc_form', 0, 0 );
+                }
+
+                //getting arrays for editors and groups
+                postData.editors = funcs.checkAndAddEditors(userInfo, postData);
+                postData.groups = funcs.convertToArray(postData.groups);
+
+                dbMethods.editDiscInDB(discAllias, userInfo, postData, db, err => {
+                  if (err) return bw.redirectTo500Page(response, err, callback);
+
+                  discAllias = postData.allias;
+                  console.log(`Discipline ${discAllias} updated!`);
+
+                  return bw.redirectToDiscByAllias(response, discAllias, callback);
+                });//editDiscInDB
+
+              } catch(err) {
+                console.log(`Proccesor error disc_update: ${err}`);
+                return bw.redirectTo500Page(response, err, callback);
+              }
+            }); //downloadClientPostData
+          }); //getAllTeachers
+        }); //getAllGroups
+      }); //findDisciplineByAllias
+    }); //getRoleForAuthedUser
   }
-}
-function convertToArray(element) {
-  if(typeof element === 'string'){
-    return [element];
-  } else{
-    return element;
-  }
-}
+};

--- a/templates/test/processors/disciplines/dbMethods.js
+++ b/templates/test/processors/disciplines/dbMethods.js
@@ -1,0 +1,152 @@
+const ObjectID = require('mongodb').ObjectID;
+
+module.exports = {
+  getRoleForAuthedUser,
+  getAllGroups,
+  getAllTeachers,
+  findDisciplineByAllias,
+  findDisciplineFiles,
+  addDisciplineToDB,
+  editDiscInDB,
+  deleteFileFromDB,
+  deleteDiscFromDB,
+  getAllUserInfo,
+  aggregateDisciplinesWithEditorsAndGroups
+};
+
+
+/*COMMON METHODS*/
+function getRoleForAuthedUser(userID, db, callback) {
+  db.collection('users').findOne(
+    { _id: new ObjectID(userID) },
+    { _id: 1, securityRole: 1 },
+    callback);
+}
+
+function getAllGroups(db, callback) {
+  db.collection('groups').find().toArray(callback);
+}
+
+function getAllTeachers(db, callback) {
+  db.collection('users').find({ securityRole: 'teacher' }).toArray(callback);
+}
+
+function findDisciplineByAllias(disciplineAllias, db, callback) {
+  db.collection('disciplines').findOne(
+    { allias: disciplineAllias },
+    callback );
+}
+
+/*DETAIL METHODS*/
+function findDisciplineFiles(files, db, callback) {
+  db.collection('files').find(
+    { _id: { $in: files } })
+    .sort({ dateEdit: -1 })
+    .toArray(callback);
+}
+
+/*CREATE METHODS*/
+function addDisciplineToDB(user, discInfo, db, callback) {
+  db.collection('disciplines').insertOne({
+    name: discInfo.name,
+    mnemo: discInfo.mnemo,
+    allias: discInfo.allias,
+    description: discInfo.description,
+    creator: user._id.toString(),
+    dateCreate: new Date(),
+    dateUpdate: new Date(),
+    lastEditor: user._id.toString(),
+    editors: discInfo.editors,
+    groups: discInfo.groups,
+    files: []
+  }, callback);
+}
+/*EDIT METHODS*/
+function editDiscInDB(discAllias, userInfo, discInfo, db, callback) {
+  db.collection('disciplines').findOneAndUpdate(
+    { allias: discAllias },
+    { $set: {
+        name: discInfo.name,
+        mnemo: discInfo.mnemo,
+        allias: discInfo.allias,
+        description: discInfo.description,
+        groups: discInfo.groups,
+        dateUpdate: new Date(),
+        lastEditor: userInfo._id,
+        editors: discInfo.editors
+      }
+    },
+    callback);
+}
+/*DELETE METHODS*/
+function deleteFileFromDB(fileID, db, callback) {
+  db.collection("files").deleteOne(
+    { _id: fileID },
+    callback);
+}
+
+function deleteDiscFromDB(allias, db, callback) {
+  db.collection('disciplines').deleteOne(
+    { allias: allias },
+    callback);
+}
+
+/*GET METHODS*/
+function getAllUserInfo(userID, db, callback) {
+  db.collection('users').findOne(
+    { _id: new ObjectID(userID) },
+    callback);
+}
+
+function aggregateDisciplinesWithEditorsAndGroups(db, callback) {
+  db.collection('disciplines').aggregate([
+    {
+      $lookup: { // like join in SQL
+        from: 'groups', // from collection with name 'groups'
+        let: { groups: '$groups' }, //declare var from 'disciplines' collection
+        pipeline: [
+          {
+            $match: { // for all matched documents
+              $expr: {
+                // where _id from 'groups' collection
+                // exists in array '$$groups' (from 'disciplines' collection)
+                $in: [ {$toString: '$_id'}, '$$groups' ]
+              }
+            }
+          },
+          {
+            $project: { // what fields needed
+              _id: 0, fullname: 1, name: 1, course: 1, typeEducation: 1
+            }
+          },
+        ], // end pipeline
+        as: 'groupsInfo'
+      } //end $lookup
+    },
+    {
+      $lookup: {
+        from: 'users',
+        let: { editors: '$editors'},
+        pipeline: [
+          {
+            $match: { // for all matched documents
+              $expr: {
+                // where _id from 'users' collection
+                // exists in array '$$editors' (from 'disciplines' collection)
+                $in: [ {$toString: '$_id'}, '$$editors' ]
+              }
+            }
+          },
+          {
+            $project: { // what fields needed
+              _id: 0, lastName: 1, name: 1, fatherName: 1
+            }
+          },
+        ], // end pipeline
+            as: 'editorsInfo'
+      } //end $lookup
+    },
+  ]) // end aggregate
+  .sort({ name: 1 })
+  .toArray(callback);
+}

--- a/templates/test/processors/disciplines/funcs.js
+++ b/templates/test/processors/disciplines/funcs.js
@@ -1,0 +1,118 @@
+const fs = require('fs'),
+      path = require('path'),
+      deleteFileFromDB = require('./dbMethods.js').deleteFileFromDB;
+
+/*CONST VARS*/
+const STORAGE_DATA_LOCATION = process.env['STORAGE_DATA_LOCATION'] ?
+                        `${process.env['STORAGE_DATA_LOCATION']}/private` : '',
+      PATH_TO_FILES_DIR = STORAGE_DATA_LOCATION ||
+                          path.join(__dirname, '../../../../', '/data/private');
+
+module.exports = {
+  checkDiscAllias,
+  checkAndAddEditors,
+  convertToArray,
+  getDiscAlliasFromUrl,
+  deleteDisciplineFiles
+}
+
+function checkDiscAllias(allias) {
+  const russianRegexp = new RegExp(/[А-яЁё]/gi);
+  if (russianRegexp.test(allias)) {
+    return 'Имя ссылки(URL) должно быть на английском!';
+  }
+
+  const protocolRegexp = new RegExp(/\/|http|@|:|ftp/gi);
+  if (protocolRegexp.test(allias)) {
+    return 'Неправильное имя ссылки(URL) для дисциплины!';
+  }
+
+  return '';
+}
+
+function checkAndAddEditors(user, postData) {
+  const userID = user._id.toString();
+  //if key not exist, this means, what teacher create discipline, add his ID
+  if (!postData.editors) return convertToArray(userID);
+
+  //if one editor, he will be with type string. Convert to array.
+  return convertToArray(postData.editors);
+}
+
+function convertToArray(element) {
+  if (Array.isArray(element)) return element;
+  if (typeof element === 'string') return [element];
+  if (typeof element === 'undefined') return [];
+  if (typeof element === 'object') return Object.entries(element);
+  return element;
+}
+
+function getDiscAlliasFromUrl(clientUrl) {
+  let requestedURL = decodeURI(clientUrl);
+  const delimeteredURL = requestedURL.split('/');
+  return delimeteredURL[delimeteredURL.length - 2];
+}
+
+/*DELETE FUNCS*/
+function deleteDisciplineFiles(fileIDs, db, callback) {
+  let errorCounter = 0;
+  for (let fileID of fileIDs) {
+
+    deleteFileFromServer(fileID, err => {
+
+      if (err) {
+        console.log(`Error deleting file ${fileID} from server: ${err}`);
+        errorCounter++;
+      }
+      const dirName = fileID.substr(0,2);
+
+      deleteDirIfEmpty(dirName, err => {
+        if (err) {
+          console.log(`Error deleting dir ${dirName}: ${err}`);
+          errorCounter++;
+        }
+        // required from /disciplines/dbMethods.js
+        deleteFileFromDB(fileID, db, err => {
+          if (err) {
+            console.log(`Error deleting file ${fileID} from DB: ${err}`);
+            errorCounter++;
+          }
+        }); //deleteFileFromDB
+      }); //deleteDirIfEmpty
+    }); //deleteFileFromServer
+  }
+  return callback(errorCounter);
+}
+
+function deleteFileFromServer(fileID, callback) {
+  const dirName = fileID.substr(0, 2);
+  const pathToCurrentFile = `${PATH_TO_FILES_DIR}/${dirName}/${fileID}`;
+  checkExistPath(pathToCurrentFile, checkedPath => {
+    if (checkedPath == null) return callback(null);
+    return fs.unlink(checkedPath, callback);
+  });
+}
+
+function deleteDirIfEmpty(dirName, callback) {
+  const pathToCurrentDir = `${PATH_TO_FILES_DIR}/${dirName}`;
+  checkExistPath(pathToCurrentDir, checkedPath => {
+    if (checkedPath == null) return callback(null);
+
+    fs.readdir(checkedPath, (err, files) => {
+      if (err) return callback(err);
+      if (files.length) return callback(null);
+      fs.rmdir(pathToCurrentDir, (err) => {
+        if (err) return callback(err);
+        return callback(null);
+      }); // fs.rmdir
+    }); // fs.readdir
+  }); // checkExistPath
+}
+
+function checkExistPath(pathForCheck, callback) {
+  if( !fs.existsSync(pathForCheck) ) {
+    console.log(`${pathForCheck} not existent`);
+    return callback(null);
+  }
+  return callback(pathForCheck);
+}


### PR DESCRIPTION
Decided to move db queries and repeating operations from disciplines processors.
This will be increase readability of the disc processors code.

For the purposes described above сreated "disciplines" direcroty:

- funcs — include operations without using DB (for example getDiscAlliasFromUrl)
- dbMethods — include only DB queries to Mongo.

Also used functionality from "common" directory: 

- permission_check.js — checking is user authed and user roles 
- bleed_wrapper.js — redirecting to common and error pages

Next step - rewrite old disc processors with using modules described above.
In disc_create.js and disc_edit.js added logic for checking new allias with existent discipline allias in DB.